### PR TITLE
#164826019 Completes user login mutation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Population-Management-System
 
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=popout-square&logo=graphql&logoColor=violet)
+
 [![CircleCI](https://circleci.com/gh/chukwuemekachm/Population-Management-System/tree/develop.svg?style=svg)](https://circleci.com/gh/chukwuemekachm/Population-Management-System/tree/develop) [![Coverage Status](https://coveralls.io/repos/github/chukwuemekachm/Population-Management-System/badge.svg?branch=develop)](https://coveralls.io/github/chukwuemekachm/Population-Management-System?branch=develop)
+
 Population Management System is an API that contains a list of locations and the total number of residents in each location broken down by gender

--- a/package.json
+++ b/package.json
@@ -20,8 +20,9 @@
     "dev": "nodemon --exec ts-node -- src/index.ts",
     "prisma": "prisma deploy",
     "generate:type": "graphqlgen",
-    "test": "jest",
-    "coverage": "jest --coverage --coverageReporters=text-lcov | coveralls"
+    "test": "jest --runInBand",
+    "coverage": "jest --runInBand --coverage --coverageReporters=text-lcov | coveralls",
+    "watch": "jest --runInBand --watch"
   },
   "bugs": {
     "url": "https://github.com/chukwuemekachm/Population-Management-System/issues"

--- a/src/graphql/__tests__/mutations/__snapshots__/login.spec.ts.snap
+++ b/src/graphql/__tests__/mutations/__snapshots__/login.spec.ts.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`login mutation should return an unauthenticated error response when the password does not match 1`] = `
+Array [
+  [GraphQLError: Invaild credentials],
+]
+`;
+
+exports[`login mutation should return an unauthenticated error response when the user does not exist 1`] = `
+Array [
+  [GraphQLError: Invaild credentials],
+]
+`;
+
+exports[`login mutation should return authenticated user profile when credentials are valid 1`] = `
+Object {
+  "login": Object {
+    "user": Object {
+      "firstName": "Test",
+      "lastName": "User",
+    },
+  },
+}
+`;
+
+exports[`login mutation should return validation errors when inputs are not provided 1`] = `
+Array [
+  [GraphQLError: Some field(s) are failing validation],
+]
+`;

--- a/src/graphql/__tests__/mutations/login.spec.ts
+++ b/src/graphql/__tests__/mutations/login.spec.ts
@@ -1,0 +1,93 @@
+import { createTestClient } from 'apollo-server-testing';
+
+import graphqlTestServer from '../../__mocks__/server.graphql';
+import prismaTestMockClient from '../../__mocks__/prisma';
+import { LOGIN_MUTATION, SIGNUP_MUTATION } from '../../constants';
+import { userInputs } from '../../fixtures/userFixtures';
+
+const { mutate } = createTestClient(graphqlTestServer);
+
+describe('login mutation', () => {
+  beforeAll(async () => {
+    await prismaTestMockClient.deleteManyUsers();
+    const payload = {
+      variables: {
+        user: userInputs[1],
+      },
+    };
+    await mutate({
+      mutation: SIGNUP_MUTATION,
+      ...payload,
+    });
+  });
+  afterAll(async () => {
+    await prismaTestMockClient.deleteManyUsers();
+  });
+
+  test('should return authenticated user profile when credentials are valid', async () => {
+    const payload = {
+      variables: {
+        user: {
+          email: userInputs[1].email,
+          password: userInputs[1].password,
+        },
+      },
+    };
+    const { errors, data } = await mutate({
+      mutation: LOGIN_MUTATION,
+      ...payload,
+    });
+    expect(errors).toBeUndefined();
+    expect(data).toBeDefined();
+    expect(data).toMatchSnapshot();
+  });
+
+  test('should return validation errors when inputs are not provided', async () => {
+    const payload = {
+      variables: {},
+    };
+    const { errors, data } = await mutate({
+      mutation: LOGIN_MUTATION,
+      ...payload,
+    });
+    expect(errors).toBeDefined();
+    expect(data).toBeNull();
+    expect(errors).toMatchSnapshot();
+  });
+
+  test('should return an unauthenticated error response when the user does not exist', async () => {
+    const payload = {
+      variables: {
+        user: {
+          email: userInputs[2].email,
+          password: userInputs[2].password,
+        },
+      },
+    };
+    const { errors, data } = await mutate({
+      mutation: LOGIN_MUTATION,
+      ...payload,
+    });
+    expect(errors).toBeDefined();
+    expect(data).toBeNull();
+    expect(errors).toMatchSnapshot();
+  });
+
+  test('should return an unauthenticated error response when the password does not match', async () => {
+    const payload = {
+      variables: {
+        user: {
+          email: userInputs[1].email,
+          password: 'Mismatch',
+        },
+      },
+    };
+    const { errors, data } = await mutate({
+      mutation: LOGIN_MUTATION,
+      ...payload,
+    });
+    expect(errors).toBeDefined();
+    expect(data).toBeNull();
+    expect(errors).toMatchSnapshot();
+  });
+});

--- a/src/graphql/constants/mutation.ts
+++ b/src/graphql/constants/mutation.ts
@@ -11,3 +11,14 @@ export const SIGNUP_MUTATION = gql`
     }
   }
 `;
+
+export const LOGIN_MUTATION = gql`
+  mutation login($user: LoginInput) {
+    login(user: $user) {
+      user {
+        firstName
+        lastName
+      }
+    }
+  }
+`;

--- a/src/graphql/resolvers/Mutation/__tests__/AuthMutation.spec.ts
+++ b/src/graphql/resolvers/Mutation/__tests__/AuthMutation.spec.ts
@@ -5,7 +5,7 @@ import users, { userInputs } from '../../../fixtures/userFixtures';
 import { validationMessage } from '../../../validators';
 
 describe('AuthMution', () => {
-  beforeAll(async () => {
+  beforeEach(async () => {
     await prismaTestMockClient.deleteManyUsers();
     await prismaTestMockClient.createUser(userInputs[1]);
   });
@@ -37,6 +37,54 @@ describe('AuthMution', () => {
     test('should throw validation errors if the inputs are not valid', async () => {
       try {
         await AuthMutation.signup(
+          undefined,
+          { user: userInputs[0] },
+          context,
+          undefined,
+        );
+      } catch ({ message }) {
+        expect(message).toEqual(validationMessage);
+      }
+    });
+  });
+
+  describe('Login', () => {
+    test('should authenticate a user when valid information is provided', async () => {
+      await AuthMutation.signup(
+        undefined,
+        { user: userInputs[2] },
+        context,
+        undefined,
+      );
+
+      const args = {
+        user: {
+          email: userInputs[2].email,
+          password: userInputs[2].password,
+        },
+      };
+      const result = await AuthMutation.login(
+        undefined,
+        args,
+        context,
+        undefined,
+      );
+      expect(result.token).toBeDefined();
+      expect(result.user).toBeDefined();
+      expect(result.user).toHaveProperty('id');
+      expect(result.user).toHaveProperty('email');
+      expect(result.user).toHaveProperty('firstName');
+      expect(result.user).toHaveProperty('lastName');
+      expect(result.user).toHaveProperty('updatedAt');
+      expect(result.user).toHaveProperty('createdAt');
+      expect(result.user.email).toEqual(userInputs[2].email);
+      expect(result.user.firstName).toEqual(userInputs[2].firstName);
+      expect(result.user.lastName).toEqual(userInputs[2].lastName);
+    });
+
+    test('should throw validation errors if the inputs are not valid', async () => {
+      try {
+        await AuthMutation.login(
           undefined,
           { user: userInputs[0] },
           context,

--- a/src/graphql/resolvers/Mutation/index.ts
+++ b/src/graphql/resolvers/Mutation/index.ts
@@ -1,8 +1,16 @@
 import AuthMutation from './AuthMutation';
-import { ArgsSignup } from '../../types/resolvers/mutation/AuthMutation';
+import {
+  ArgsSignup,
+  ArgsLogin,
+} from '../../types/resolvers/mutation/AuthMutation';
 import { Context } from '../../types/types';
+import MutationResolvers from '../../types/resolvers/mutation';
 
-export default {
+const mutation: MutationResolvers = {
   signup: (parent: undefined, args: ArgsSignup, context: Context) =>
     AuthMutation.signup(parent, args, context),
+  login: (parent: undefined, args: ArgsLogin, context: Context) =>
+    AuthMutation.login(parent, args, context),
 };
+
+export default mutation;

--- a/src/graphql/resolvers/index.ts
+++ b/src/graphql/resolvers/index.ts
@@ -4,10 +4,12 @@ import User from './User';
 import AuthResponse from './AuthResponse';
 import Location from './Location';
 
-export default {
+const resolvers = {
   Query,
   Mutation,
   AuthResponse,
-  // User,
-  // Location,
+  User,
+  Location,
 };
+
+export default resolvers;

--- a/src/graphql/schema.ts
+++ b/src/graphql/schema.ts
@@ -9,6 +9,7 @@ const typeDefs = gql`
 
   type Mutation {
     signup(user: SignupInput): AuthResponse!
+    login(user: LoginInput): AuthResponse!
   }
 
   type AuthResponse {
@@ -19,6 +20,11 @@ const typeDefs = gql`
   input SignupInput {
     firstName: String!
     lastName: String!
+    email: String!
+    password: String!
+  }
+
+  input LoginInput {
     email: String!
     password: String!
   }
@@ -41,6 +47,7 @@ const typeDefs = gql`
     totalResidents: Int!
     parentLocationId: ID
     subLocations: [Location!]!
+    creator: User!
     createdAt: DateTime!
     updatedAt: DateTime!
   }

--- a/src/graphql/types/resolvers/mutation/AuthMutation.ts
+++ b/src/graphql/types/resolvers/mutation/AuthMutation.ts
@@ -8,8 +8,17 @@ export interface SignupInput {
   password: string;
 }
 
+export interface LoginInput {
+  email: string;
+  password: string;
+}
+
 export interface ArgsSignup {
   user: SignupInput;
+}
+
+export interface ArgsLogin {
+  user: LoginInput;
 }
 
 export type SignupResolver = (
@@ -19,8 +28,16 @@ export type SignupResolver = (
   info?: GraphQLResolveInfo | null,
 ) => AuthResponse | Promise<AuthResponse>;
 
+export type LoginResolver = (
+  parent: undefined,
+  args: ArgsLogin,
+  ctx: Context,
+  info?: GraphQLResolveInfo | null,
+) => AuthResponse | Promise<AuthResponse>;
+
 interface AuthMutation {
   signup: SignupResolver;
+  login: LoginResolver;
 }
 
 export default AuthMutation;

--- a/src/graphql/types/resolvers/mutation/index.ts
+++ b/src/graphql/types/resolvers/mutation/index.ts
@@ -1,7 +1,9 @@
-import { SignupResolver } from './AuthMutation';
+import { SignupResolver, LoginResolver } from './AuthMutation';
 
 interface MutationResolvers {
   signup: SignupResolver;
+  login: LoginResolver;
+  [key: string]: any;
 }
 
 export default MutationResolvers;

--- a/src/graphql/validators/UserValidator.ts
+++ b/src/graphql/validators/UserValidator.ts
@@ -1,4 +1,4 @@
-import { Length, IsEmail, IsAlphanumeric } from 'class-validator';
+import { Length, IsEmail, IsOptional, IsAlphanumeric } from 'class-validator';
 
 interface IUserValidatorPayload {
   firstName: string;
@@ -8,9 +8,11 @@ interface IUserValidatorPayload {
 }
 
 export class UserValidator implements IUserValidatorPayload {
+  @IsOptional()
   @Length(2, 50)
   firstName: string;
 
+  @IsOptional()
   @Length(2, 50)
   lastName: string;
 


### PR DESCRIPTION
#### What does this PR do?
- This PR completes the user login mutation to enable a user how has created an account to authenticate themselves and get an authorization token.
#### Description of Task to be completed?
- add require type definitions
- add login resolver
- write unit and integration tests for login resolver and functionality
#### How should this be manually tested?
- Set up the project locally
- Open your browser and create a `login mutation` on this endpoint `localhost:<PORT>/graphql`
- Observe the behaviour
#### Any background context you want to provide?
- N/A
#### What are the relevant pivotal tracker stories?
- [#164826019](https://www.pivotaltracker.com/story/show/164826019)
#### Screenshots (if appropriate)

![Screenshot 2019-03-29 at 2 57 43 PM](https://user-images.githubusercontent.com/33798252/55239190-6e139700-5236-11e9-8197-aaa56af1e6f1.png)


<img width="723" alt="Screenshot 2019-03-29 at 12 55 05 AM" src="https://user-images.githubusercontent.com/33798252/55239191-6e139700-5236-11e9-95f4-b4747f74829a.png">

#### Questions:
- N/A